### PR TITLE
Update Jenkinsfile to use dynamic Docker tag based on branch type

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -63,7 +63,7 @@ pipeline {
                     sh """
                         docker run -d --name test-container \
                             --network test-network \
-                            -e DATABASE_URL=postgresql://postgres:p\@ssw0rd@test-db:5432/deepfij \
+                            -e DATABASE_URL=postgresql://postgres:p@ssw0rd\\@test-db:5432/deepfij \
                             -e FLASK_APP=app.py \
                             -e FLASK_ENV=production \
                             -p 8000:8000 \


### PR DESCRIPTION
- Introduced `dockerTag` variable to differentiate tags for release and non-release branches.
- Improved readability and consistency in Docker-related scripting using multi-line strings (`"""`).